### PR TITLE
fix: duplicate scaleShowGridLines property

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -46,7 +46,6 @@ $(function() {
     showScale: false,
     scaleShowGridLines: false,
     scaleBeginAtZero: true,
-    scaleShowGridLines: true,
     scaleGridLineColor: "rgba(0,0,0,.05)",
     scaleGridLineWidth: 1,
     scaleShowHorizontalLines: false,


### PR DESCRIPTION
fix: duplicate scaleShowGridLines property in jumbotron-bar-chart ChartJS definition